### PR TITLE
Fix the Makefile setup command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,12 @@ dist: wasm
 dist-dev: wasm
 	@cd demo && yarn build:dev
 
-module:
-	@cd module && yarn build
-
-setup: wasm snap-wasm module
+setup: wasm snap-wasm
 	@cd demo && yarn install && npx playwright install
-	@cd module && yarn install
-	@cd snap/rpc && yarn install
-	@cd snap/ui && yarn install
+	@cd packages/wasm/pkg && yarn install
+	@cd packages/client && yarn install
+	@cd snap/dapp && yarn install
+	@cd snap/wasm/pkg && yarn install
 
 build:
 	@cd cli && cargo build
@@ -52,4 +50,4 @@ fmt: lint
 	@cd packages/wasm && cargo fmt
 	@cd snap/wasm && cargo fmt
 
-.PHONY: wasm snap-wasm dist dist-dev module setup build release server demo test lint fmt
+.PHONY: wasm snap-wasm dist dist-dev setup build release server demo test lint fmt


### PR DESCRIPTION
See this for reference, https://github.com/LavaMoat/demo-gg20-wasm/issues/75#issuecomment-1237564032. 

Remove the unused `module` command and fix the `setup` command in `Makefile`