### PR TITLE
Improve readme doc for yarn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ cargo install --version 0.10.2 wasm-pack
 
 ```
 make setup
+cd packages/client && yarn build && yarn link && cd ../..
+cd demo && yarn link @metamask/mpc-client && cd ..
 ```
 
 ## Serve


### PR DESCRIPTION
Improve the README doc to address the issue where the package `@metamask/mpc-client` does not get linked properly if `yarn build` is not run in the `packages/client` folder.

See https://github.com/LavaMoat/demo-gg20-wasm/issues/75#issuecomment-1237579093 for reference.
